### PR TITLE
This makes the pointless tap-to-refresh button go away after refresh.

### DIFF
--- a/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
+++ b/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
@@ -271,7 +271,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     private void resetHeader() {
         if (mRefreshState != TAP_TO_REFRESH) {
             mRefreshState = TAP_TO_REFRESH;
-
+            smoothScrollBy(mRefreshViewHeight,10);
             resetHeaderPadding();
 
             // Set refresh view text to the pull label


### PR DESCRIPTION
This library is one of the best pull-to-refresh libraries, it is not perfect, but it is close. Lets develop it to perfection. It is not as fast as the Twitter client for Android, how can we speed it up, any ideas?? Please take this commit, I don't see any point in the tap-to-refresh button.
