### PR TITLE
Vertical scrolling not working in Android 4.1 (Jelly Bean). 

### DIFF
--- a/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
+++ b/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
@@ -116,6 +116,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
 
     @Override
     protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
         setSelection(1);
     }
 


### PR DESCRIPTION
"onAttachedWindow()" method in PullToRefreshListView  needs to call "super.onAttachedToWindow()".
