### PR TITLE
Remove "Tap to Refresh" For Short List

### DIFF
--- a/pulltorefresh/res/layout/pull_to_refresh_header.xml
+++ b/pulltorefresh/res/layout/pull_to_refresh_header.xml
@@ -17,8 +17,8 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:paddingTop="10dip"
-    android:paddingBottom="15dip"
+    android:paddingTop="0dip"
+    android:paddingBottom="0dip"
     android:gravity="center"
         android:id="@+id/pull_to_refresh_header"
     >

--- a/pulltorefresh/res/layout/pull_to_refresh_header.xml
+++ b/pulltorefresh/res/layout/pull_to_refresh_header.xml
@@ -47,7 +47,7 @@
         />
     <TextView
         android:id="@+id/pull_to_refresh_text"
-        android:text="@string/pull_to_refresh_tap_label"
+        android:text="@string/pull_to_refresh_pull_label"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textStyle="bold"
         android:paddingTop="5dip"
@@ -55,6 +55,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:gravity="center"
+        android:visibility="gone"
         />
     <TextView
         android:id="@+id/pull_to_refresh_updated_at"

--- a/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
+++ b/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
@@ -1,6 +1,5 @@
 package com.markupartist.android.widget;
 
-
 import android.content.Context;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -11,50 +10,49 @@ import android.view.ViewGroup;
 import android.view.animation.LinearInterpolator;
 import android.view.animation.RotateAnimation;
 import android.widget.AbsListView;
+import android.widget.AbsListView.OnScrollListener;
 import android.widget.ImageView;
 import android.widget.ListAdapter;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
-import android.widget.AbsListView.OnScrollListener;
 
 import com.markupartist.android.widget.pulltorefresh.R;
 
 public class PullToRefreshListView extends ListView implements OnScrollListener {
 
-    private static final int TAP_TO_REFRESH = 1;
-    private static final int PULL_TO_REFRESH = 2;
-    private static final int RELEASE_TO_REFRESH = 3;
-    private static final int REFRESHING = 4;
+    private static final int    PULL_TO_REFRESH    = 2;
+    private static final int    RELEASE_TO_REFRESH = 3;
+    private static final int    REFRESHING         = 4;
 
-    private static final String TAG = "PullToRefreshListView";
+    private static final String TAG                = "PullToRefreshListView";
 
-    private OnRefreshListener mOnRefreshListener;
+    private OnRefreshListener   mOnRefreshListener;
 
     /**
      * Listener that will receive notifications every time the list scrolls.
      */
-    private OnScrollListener mOnScrollListener;
-    private LayoutInflater mInflater;
+    private OnScrollListener    mOnScrollListener;
+    private LayoutInflater      mInflater;
 
-    private RelativeLayout mRefreshView;
-    private TextView mRefreshViewText;
-    private ImageView mRefreshViewImage;
-    private ProgressBar mRefreshViewProgress;
-    private TextView mRefreshViewLastUpdated;
+    private RelativeLayout      mRefreshView;
+    private TextView            mRefreshViewText;
+    private ImageView           mRefreshViewImage;
+    private ProgressBar         mRefreshViewProgress;
+    private TextView            mRefreshViewLastUpdated;
 
-    private int mCurrentScrollState;
-    private int mRefreshState;
+    private int                 mCurrentScrollState;
+    private int                 mRefreshState;
 
-    private RotateAnimation mFlipAnimation;
-    private RotateAnimation mReverseFlipAnimation;
+    private RotateAnimation     mFlipAnimation;
+    private RotateAnimation     mReverseFlipAnimation;
 
-    private int mRefreshViewHeight;
-    private int mRefreshOriginalTopPadding;
-    private int mLastMotionY;
+    private int                 mRefreshViewHeight;
+    private int                 mRefreshOriginalTopPadding;
+    private int                 mLastMotionY;
 
-    private boolean mBounceHack;
+    private boolean             mBounceHack;
 
     public PullToRefreshListView(Context context) {
         super(context);
@@ -73,38 +71,28 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
 
     private void init(Context context) {
         // Load all of the animations we need in code rather than through XML
-        mFlipAnimation = new RotateAnimation(0, -180,
-                RotateAnimation.RELATIVE_TO_SELF, 0.5f,
-                RotateAnimation.RELATIVE_TO_SELF, 0.5f);
+        mFlipAnimation = new RotateAnimation(0, -180, RotateAnimation.RELATIVE_TO_SELF, 0.5f, RotateAnimation.RELATIVE_TO_SELF, 0.5f);
         mFlipAnimation.setInterpolator(new LinearInterpolator());
         mFlipAnimation.setDuration(250);
         mFlipAnimation.setFillAfter(true);
-        mReverseFlipAnimation = new RotateAnimation(-180, 0,
-                RotateAnimation.RELATIVE_TO_SELF, 0.5f,
-                RotateAnimation.RELATIVE_TO_SELF, 0.5f);
+        mReverseFlipAnimation = new RotateAnimation(-180, 0, RotateAnimation.RELATIVE_TO_SELF, 0.5f, RotateAnimation.RELATIVE_TO_SELF, 0.5f);
         mReverseFlipAnimation.setInterpolator(new LinearInterpolator());
         mReverseFlipAnimation.setDuration(250);
         mReverseFlipAnimation.setFillAfter(true);
 
-        mInflater = (LayoutInflater) context.getSystemService(
-                Context.LAYOUT_INFLATER_SERVICE);
+        mInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
 
-		mRefreshView = (RelativeLayout) mInflater.inflate(
-				R.layout.pull_to_refresh_header, this, false);
-        mRefreshViewText =
-            (TextView) mRefreshView.findViewById(R.id.pull_to_refresh_text);
-        mRefreshViewImage =
-            (ImageView) mRefreshView.findViewById(R.id.pull_to_refresh_image);
-        mRefreshViewProgress =
-            (ProgressBar) mRefreshView.findViewById(R.id.pull_to_refresh_progress);
-        mRefreshViewLastUpdated =
-            (TextView) mRefreshView.findViewById(R.id.pull_to_refresh_updated_at);
+        mRefreshView = (RelativeLayout) mInflater.inflate(R.layout.pull_to_refresh_header, this, false);
+        mRefreshViewText = (TextView) mRefreshView.findViewById(R.id.pull_to_refresh_text);
+        mRefreshViewImage = (ImageView) mRefreshView.findViewById(R.id.pull_to_refresh_image);
+        mRefreshViewProgress = (ProgressBar) mRefreshView.findViewById(R.id.pull_to_refresh_progress);
+        mRefreshViewLastUpdated = (TextView) mRefreshView.findViewById(R.id.pull_to_refresh_updated_at);
 
         mRefreshViewImage.setMinimumHeight(50);
         mRefreshView.setOnClickListener(new OnClickRefreshListener());
         mRefreshOriginalTopPadding = mRefreshView.getPaddingTop();
 
-        mRefreshState = TAP_TO_REFRESH;
+        mRefreshState = PULL_TO_REFRESH;
 
         addHeaderView(mRefreshView);
 
@@ -112,6 +100,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
 
         measureView(mRefreshView);
         mRefreshViewHeight = mRefreshView.getMeasuredHeight();
+
     }
 
     @Override
@@ -123,7 +112,6 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     @Override
     public void setAdapter(ListAdapter adapter) {
         super.setAdapter(adapter);
-
         setSelection(1);
     }
 
@@ -131,7 +119,8 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
      * Set the listener that will receive notifications every time the list
      * scrolls.
      * 
-     * @param l The scroll listener. 
+     * @param l
+     *            The scroll listener.
      */
     @Override
     public void setOnScrollListener(AbsListView.OnScrollListener l) {
@@ -141,15 +130,18 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     /**
      * Register a callback to be invoked when this list should be refreshed.
      * 
-     * @param onRefreshListener The callback to run.
+     * @param onRefreshListener
+     *            The callback to run.
      */
     public void setOnRefreshListener(OnRefreshListener onRefreshListener) {
         mOnRefreshListener = onRefreshListener;
     }
 
     /**
-     * Set a text to represent when the list was last updated. 
-     * @param lastUpdated Last updated at.
+     * Set a text to represent when the list was last updated.
+     * 
+     * @param lastUpdated
+     *            Last updated at.
      */
     public void setLastUpdated(CharSequence lastUpdated) {
         if (lastUpdated != null) {
@@ -171,15 +163,12 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
                     setVerticalScrollBarEnabled(true);
                 }
                 if (getFirstVisiblePosition() == 0 && mRefreshState != REFRESHING) {
-                    if ((mRefreshView.getBottom() >= mRefreshViewHeight
-                            || mRefreshView.getTop() >= 0)
-                            && mRefreshState == RELEASE_TO_REFRESH) {
+                    if ((mRefreshView.getBottom() >= mRefreshViewHeight || mRefreshView.getTop() >= 0) && mRefreshState == RELEASE_TO_REFRESH) {
                         // Initiate the refresh
                         mRefreshState = REFRESHING;
                         prepareForRefresh();
                         onRefresh();
-                    } else if (mRefreshView.getBottom() < mRefreshViewHeight
-                            || mRefreshView.getTop() <= 0) {
+                    } else if (mRefreshView.getBottom() < mRefreshViewHeight || mRefreshView.getTop() <= 0) {
                         // Abort refresh and scroll down below the refresh view
                         resetHeader();
                         setSelection(1);
@@ -201,24 +190,17 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
         int pointerCount = ev.getHistorySize();
 
         for (int p = 0; p < pointerCount; p++) {
-            if (mRefreshState == RELEASE_TO_REFRESH) {
-                if (isVerticalFadingEdgeEnabled()) {
-                    setVerticalScrollBarEnabled(false);
-                }
-
-                int historicalY = (int) ev.getHistoricalY(p);
-
-                // Calculate the padding to apply, we divide by 1.7 to
-                // simulate a more resistant effect during pull.
-                int topPadding = (int) (((historicalY - mLastMotionY)
-                        - mRefreshViewHeight) / 1.7);
-
-                mRefreshView.setPadding(
-                        mRefreshView.getPaddingLeft(),
-                        topPadding,
-                        mRefreshView.getPaddingRight(),
-                        mRefreshView.getPaddingBottom());
+            if (isVerticalFadingEdgeEnabled()) {
+                setVerticalScrollBarEnabled(false);
             }
+
+            int historicalY = (int) ev.getHistoricalY(p);
+
+            // Calculate the padding to apply, we divide by 1.7 to
+            // simulate a more resistant effect during pull.
+            int topPadding = (int) (((historicalY - mLastMotionY) - mRefreshViewHeight) / 1.7);
+
+            mRefreshView.setPadding(mRefreshView.getPaddingLeft(), topPadding, mRefreshView.getPaddingRight(), mRefreshView.getPaddingBottom());
         }
     }
 
@@ -226,44 +208,37 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
      * Sets the header padding back to original size.
      */
     private void resetHeaderPadding() {
-        mRefreshView.setPadding(
-                mRefreshView.getPaddingLeft(),
-                mRefreshOriginalTopPadding,
-                mRefreshView.getPaddingRight(),
-                mRefreshView.getPaddingBottom());
+        mLastMotionY = 0;
+        mRefreshView.setPadding(mRefreshView.getPaddingLeft(), mRefreshOriginalTopPadding, mRefreshView.getPaddingRight(), mRefreshView.getPaddingBottom());
     }
 
     /**
      * Resets the header to the original state.
      */
     private void resetHeader() {
-        if (mRefreshState != TAP_TO_REFRESH) {
-            mRefreshState = TAP_TO_REFRESH;
+        mRefreshState = PULL_TO_REFRESH;
 
-            resetHeaderPadding();
+        resetHeaderPadding();
 
-            // Set refresh view text to the pull label
-            mRefreshViewText.setText(R.string.pull_to_refresh_tap_label);
-            // Replace refresh drawable with arrow drawable
-            mRefreshViewImage.setImageResource(R.drawable.ic_pulltorefresh_arrow);
-            // Clear the full rotation animation
-            mRefreshViewImage.clearAnimation();
-            // Hide progress bar and arrow.
-            mRefreshViewImage.setVisibility(View.GONE);
-            mRefreshViewProgress.setVisibility(View.GONE);
-        }
+        // Set refresh view text to the pull label
+        mRefreshViewText.setText(R.string.pull_to_refresh_pull_label);
+        mRefreshViewText.setVisibility(View.GONE);
+        // Replace refresh drawable with arrow drawable
+        mRefreshViewImage.setImageResource(R.drawable.ic_pulltorefresh_arrow);
+        // Clear the full rotation animation
+        mRefreshViewImage.clearAnimation();
+        // Hide progress bar and arrow.
+        mRefreshViewImage.setVisibility(View.GONE);
+        mRefreshViewProgress.setVisibility(View.GONE);
     }
 
     private void measureView(View child) {
         ViewGroup.LayoutParams p = child.getLayoutParams();
         if (p == null) {
-            p = new ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.FILL_PARENT,
-                    ViewGroup.LayoutParams.WRAP_CONTENT);
+            p = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.FILL_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT);
         }
 
-        int childWidthSpec = ViewGroup.getChildMeasureSpec(0,
-                0 + 0, p.width);
+        int childWidthSpec = ViewGroup.getChildMeasureSpec(0, 0 + 0, p.width);
         int lpHeight = p.height;
         int childHeightSpec;
         if (lpHeight > 0) {
@@ -275,37 +250,29 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     }
 
     @Override
-    public void onScroll(AbsListView view, int firstVisibleItem,
-            int visibleItemCount, int totalItemCount) {
+    public void onScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount) {
         // When the refresh view is completely visible, change the text to say
         // "Release to refresh..." and flip the arrow drawable.
-        if (mCurrentScrollState == SCROLL_STATE_TOUCH_SCROLL
-                && mRefreshState != REFRESHING) {
+        if (mCurrentScrollState == SCROLL_STATE_TOUCH_SCROLL && mRefreshState != REFRESHING) {
             if (firstVisibleItem == 0) {
                 mRefreshViewImage.setVisibility(View.VISIBLE);
-                if ((mRefreshView.getBottom() >= mRefreshViewHeight + 20
-                        || mRefreshView.getTop() >= 0)
-                        && mRefreshState != RELEASE_TO_REFRESH) {
+                if ((mRefreshView.getBottom() >= mRefreshViewHeight + 20 || mRefreshView.getTop() >= 0) && mRefreshState != RELEASE_TO_REFRESH) {
                     mRefreshViewText.setText(R.string.pull_to_refresh_release_label);
+                    mRefreshViewText.setVisibility(View.VISIBLE);
                     mRefreshViewImage.clearAnimation();
                     mRefreshViewImage.startAnimation(mFlipAnimation);
                     mRefreshState = RELEASE_TO_REFRESH;
-                } else if (mRefreshView.getBottom() < mRefreshViewHeight + 20
-                        && mRefreshState != PULL_TO_REFRESH) {
+                } else if (mRefreshView.getBottom() < mRefreshViewHeight + 20 && mRefreshState != PULL_TO_REFRESH) {
                     mRefreshViewText.setText(R.string.pull_to_refresh_pull_label);
-                    if (mRefreshState != TAP_TO_REFRESH) {
-                        mRefreshViewImage.clearAnimation();
-                        mRefreshViewImage.startAnimation(mReverseFlipAnimation);
-                    }
+                    mRefreshViewImage.clearAnimation();
+                    mRefreshViewImage.startAnimation(mReverseFlipAnimation);
                     mRefreshState = PULL_TO_REFRESH;
                 }
             } else {
                 mRefreshViewImage.setVisibility(View.GONE);
                 resetHeader();
             }
-        } else if (mCurrentScrollState == SCROLL_STATE_FLING
-                && firstVisibleItem == 0
-                && mRefreshState != REFRESHING) {
+        } else if (mCurrentScrollState == SCROLL_STATE_FLING && firstVisibleItem == 0 && mRefreshState != REFRESHING) {
             setSelection(1);
             mBounceHack = true;
         } else if (mBounceHack && mCurrentScrollState == SCROLL_STATE_FLING) {
@@ -313,8 +280,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
         }
 
         if (mOnScrollListener != null) {
-            mOnScrollListener.onScroll(view, firstVisibleItem,
-                    visibleItemCount, totalItemCount);
+            mOnScrollListener.onScroll(view, firstVisibleItem, visibleItemCount, totalItemCount);
         }
     }
 
@@ -355,7 +321,9 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
 
     /**
      * Resets the list to a normal state after a refresh.
-     * @param lastUpdated Last updated at.
+     * 
+     * @param lastUpdated
+     *            Last updated at.
      */
     public void onRefreshComplete(CharSequence lastUpdated) {
         setLastUpdated(lastUpdated);
@@ -365,7 +333,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     /**
      * Resets the list to a normal state after a refresh.
      */
-    public void onRefreshComplete() {        
+    public void onRefreshComplete() {
         Log.d(TAG, "onRefreshComplete");
 
         resetHeader();
@@ -403,8 +371,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
         /**
          * Called when the list should be refreshed.
          * <p>
-         * A call to {@link PullToRefreshListView #onRefreshComplete()} is
-         * expected to indicate that the refresh has completed.
+         * A call to {@link PullToRefreshListView #onRefreshComplete()} is expected to indicate that the refresh has completed.
          */
         public void onRefresh();
     }


### PR DESCRIPTION
Here's my fix to the "Tap to Refresh" removal. It's not using any of the odd adding of views to make it longer or anything like that, instead it simply manipulates the visibility of the header as needed and also includes a bug fix for scrolling where it was "jumpy".

This addresses #40, #24, #51, #59, and #61.
