### PR TITLE
Fixed: PullToRefreshListView would scroll to position 1 even if mRefreshView was not visible.

### DIFF
--- a/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
+++ b/pulltorefresh/src/com/markupartist/android/widget/PullToRefreshListView.java
@@ -123,7 +123,6 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
     @Override
     public void setAdapter(ListAdapter adapter) {
         super.setAdapter(adapter);
-
         setSelection(1);
     }
 
@@ -372,7 +371,7 @@ public class PullToRefreshListView extends ListView implements OnScrollListener 
 
         // If refresh view is visible when loading completes, scroll down to
         // the next item.
-        if (mRefreshView.getBottom() > 0) {
+        if (getFirstVisiblePosition() == 0) {
             invalidateViews();
             setSelection(1);
         }


### PR DESCRIPTION
Fixed an issue with onRefreshComplete() where PullToRefreshListView would scroll to position 1 even if mRefreshView was not visible.  Now I believe the code works as intended.
